### PR TITLE
Replace activate scripts with env_vars.d JSON for CPPUTEST_HOME

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,3 +1,0 @@
-# CppUTest will look for this variable to find the library
-# https://cpputest.github.io/manual.html
-export CPPUTEST_HOME="$CONDA_PREFIX"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,13 +2,9 @@
 
 set -o xtrace -o nounset -o pipefail -o errexit
 
-# Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
-# This will allow them to be run on environment activation.
-for CHANGE in "activate" "deactivate"
-do
-    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
-done
+# Set CPPUTEST_HOME via env_vars.d JSON (handled by conda at activation time).
+mkdir -p "${PREFIX}/etc/conda/env_vars.d"
+printf '{"CPPUTEST_HOME": "%s"}\n' "${PREFIX}" > "${PREFIX}/etc/conda/env_vars.d/${PKG_NAME}.json"
 
 if [[ ${CONDA_BUILD_CROSS_COMPILATION:-0} == 1 ]]; then
     BOOTSTRAP_CMAKE_ARGS=${CMAKE_ARGS//${PREFIX}/${BUILD_PREFIX}}

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,1 +1,0 @@
-unset CPPUTEST_HOME


### PR DESCRIPTION
## Summary

- Replaces `.sh` activation/deactivation scripts with a single JSON file in `etc/conda/env_vars.d/`
- conda has supported this mechanism since [conda#6820](https://github.com/conda/conda/issues/6820) — it is shell-agnostic and simpler
- conda handles prefix replacement in text files (including JSON) at install time

## Test plan

- [ ] Verify `CPPUTEST_HOME` is set correctly after `conda activate`
- [ ] Verify `CPPUTEST_HOME` is unset after `conda deactivate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)